### PR TITLE
fix: nullable marks on TextNode

### DIFF
--- a/lib/types/types.dart
+++ b/lib/types/types.dart
@@ -56,7 +56,7 @@ class TextNode extends Node<String> {
   TextNode(dynamic node) {
     value = node['value'] ?? '';
     _nodeType = node['nodeType'] ?? '';
-    marks = node['marks']?.map<Mark>((mark) => Mark(mark['type'])).toList() ?? [];
+    marks = node['marks']?.map<Mark>((mark) => Mark(mark['type'])).toList() ?? <Mark>[];
   }
 }
 

--- a/lib/types/types.dart
+++ b/lib/types/types.dart
@@ -56,9 +56,11 @@ class TextNode extends Node<String> {
   TextNode(dynamic node) {
     value = node['value'] ?? '';
     _nodeType = node['nodeType'] ?? '';
-    node['marks']?.map((mark) {
-      marks.add(Mark(mark['type']));
-    });
+    if (node['marks'] != null) {
+      node['marks'].forEach((mark) {
+        marks.add(Mark(mark['type']));
+      });
+    }
   }
 }
 

--- a/lib/types/types.dart
+++ b/lib/types/types.dart
@@ -56,11 +56,7 @@ class TextNode extends Node<String> {
   TextNode(dynamic node) {
     value = node['value'] ?? '';
     _nodeType = node['nodeType'] ?? '';
-    if (node['marks'] != null) {
-      node['marks'].forEach((mark) {
-        marks.add(Mark(mark['type']));
-      });
-    }
+    marks = node['marks']?.map<Mark>((mark) => Mark(mark['type'])).toList() ?? [];
   }
 }
 


### PR DESCRIPTION
I found that `marks` doesn't work because we used `add` within `map`.
We can either use `forEach` or `map` 

<img width="519" alt="Screen Shot 2564-09-22 at 17 53 16" src="https://user-images.githubusercontent.com/2084355/134331489-29eea954-4011-4426-a034-3e71fd321e62.png">